### PR TITLE
pass postgres as db_type

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ sonarqube:
     - DB_USER=sonar
     - DB_PASS=xaexohquaetiesoo
     - DB_NAME=sonar
+    - DB_TYPE=POSTGRES
   ports:
     - "9408:9000"
     - "443"


### PR DESCRIPTION
The docker-compose file was not working before. If the db_type is not set, mysql is chosen implicitly. Added postgres as db_type to allow running the docker-compose file